### PR TITLE
small fix on pydantic-ai-langgraph-parallelization

### DIFF
--- a/pydantic-ai-langgraph-parallelization/agent_graph.py
+++ b/pydantic-ai-langgraph-parallelization/agent_graph.py
@@ -65,7 +65,7 @@ async def gather_info(state: TravelState, writer) -> Dict[str, Any]:
         curr_response = ""
         async for message, last in result.stream_structured(debounce_by=0.01):  
             try:
-                if last and not travel_details.response:
+                if last and not (travel_details or travel_details.response):
                     raise Exception("Incorrect travel details returned by the agent.")
                 travel_details = await result.validate_structured_result(  
                     message,


### PR DESCRIPTION
Under certain circumstances this exception occurs:
```sh
UnboundLocalError: cannot access local variable 'travel_details' where it is not associated with a value
```
Model: "llama3.1:latest" ran on ollama
Prompt: I want to go to Tokyo from Minneapolis. Jun 1st, returning on 6th. I need only flight tickets, not an hotel.